### PR TITLE
Potential fix for code scanning alert no. 88: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/upload-tests-manifest.yml
+++ b/.github/workflows/upload-tests-manifest.yml
@@ -3,6 +3,9 @@
 # and test reports have been uploaded to the `test-results` artifact.
 name: Upload bundler test manifests to areweturboyet.com
 
+permissions:
+  contents: read
+
 on:
   schedule:
     - cron: '0 8 * * *'


### PR DESCRIPTION
Potential fix for [https://github.com/akabarki76/next.js/security/code-scanning/88](https://github.com/akabarki76/next.js/security/code-scanning/88)

To fix the issue, we need to add a `permissions` block to the workflow. This block should specify the least privileges required for the workflow to function correctly. Based on the workflow's actions, it primarily reads repository contents and uploads data to an external service. Therefore, the `contents: read` permission is sufficient.

The `permissions` block can be added at the root level of the workflow to apply to all jobs or within the specific job (`upload_test_results`) to limit permissions for that job only. In this case, adding it at the root level is more concise and ensures consistency across all jobs.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
