### PR TITLE
Potential fix for code scanning alert no. 282: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/codspeed.yml
+++ b/.github/workflows/codspeed.yml
@@ -1,4 +1,6 @@
 name: CodSpeed Benchmarks
+permissions:
+  contents: read
 
 # trigger on manual dispatch, pushes to canary, and daily schedule
 on:


### PR DESCRIPTION
Potential fix for [https://github.com/akabarki76/next.js/security/code-scanning/282](https://github.com/akabarki76/next.js/security/code-scanning/282)

To fix the issue, add a `permissions` block at the root of the workflow file. This block will define the minimal permissions required for the workflow to function. Based on the provided workflow, it primarily involves checking out the code, setting up Node.js, installing dependencies, and running benchmarks. These tasks typically require only `contents: read` permissions. If additional permissions are needed (e.g., for pull requests or issues), they can be added explicitly.

The `permissions` block should be added after the `name` field and before the `on` field in the workflow file.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
